### PR TITLE
Make wb-scm.sh callable from everywhere, not just its directory

### DIFF
--- a/Source/Scm/wb-scm.sh
+++ b/Source/Scm/wb-scm.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 set -x
+
+# Change to directory containing this script
+cd ${0%/*}
+
 export SCM_WORKBENCH_STDOUT_LOG=$(tty)
 
 if [ "${BUILDER_TOP_DIR}" = "" ]


### PR DESCRIPTION
wb-scm.sh presumes to be called from the directory it resides in. This simple patch makes it callable from everywhere